### PR TITLE
PluginWrapper: fix zero as null pointer constant

### DIFF
--- a/vamp-hostsdk/PluginWrapper.h
+++ b/vamp-hostsdk/PluginWrapper.h
@@ -121,7 +121,7 @@ public:
         if (w) return w;
         PluginWrapper *pw = dynamic_cast<PluginWrapper *>(m_plugin);
         if (pw) return pw->getWrapper<WrapperType>();
-        return 0;
+        return nullptr;
     }
 
     /**


### PR DESCRIPTION
This MR removes the "zero as null pointer constant" warning. 
Thank you for this great project!
